### PR TITLE
fix json tag of completionData

### DIFF
--- a/pkg/response/collect.go
+++ b/pkg/response/collect.go
@@ -55,7 +55,7 @@ type CollectResponse struct {
 	OrderRef       string         `json:"orderRef"`
 	Status         Status         `json:"status"`
 	HintCode       string         `json:"hintCode"`
-	CompletionData CompletionData `json:"CompletionData"`
+	CompletionData CompletionData `json:"completionData"`
 }
 
 func (c *CollectResponse) String() string {


### PR DESCRIPTION
It doesn't seem like the test environment is returning `completionData` at all, and I don't have access to a production environment yet, but the docs seem to indicate a typo here.

Will add unit test cases for proper response decoding, given the example JSON responses they have in the documentation.

from https://developers.bankid.com/api-references/auth--sign/collect.

```json
{
  "orderRef": "131daac9-16c6-4618-beb0-365768f37288",
  "status": "complete",
  "completionData": {
    "user": {
      "personalNumber": "200001012384",
      "name": "Alex Johnson",
      "givenName": "Alex",
      "surname": "Johnson"
    },
    "device": {
      "ipAddress": "192.168.1.1",
      "uhi": "OZvYM9VvyiAmG7NA5jU5zqGcVpo="
    },
    "bankIdIssueDate": "2023-04-01",
    "stepUp": {
      "mrtd": true
    },
    "signature": "<base64-encoded data>",
    "ocspResponse": "<base64-encoded data>",
    "risk": "low"
  }
}
```